### PR TITLE
Update base linter to 2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,10 +80,13 @@ function linter() {
      */
     function transform(message) {
         return {
-          'type': 'Error',
-          'html': toHTML(message.reason),
-          'filePath': this.getPath(),
-          'range': toRange(message.location)
+          'severity': 'error',
+          'excerpt': message.reason,
+          'description': toHTML(message.reason),
+          'location': {
+            'file': this.getPath(),
+            'position': toRange(message.location)
+          }
       };
     }
 
@@ -99,7 +102,9 @@ function linter() {
      * @return {Promise.<Message, Error>} - Promise
      *  resolved with a list of linter-errors or an error.
      */
-    function onchange(editor) {
+
+    function onchange() {
+        var editor = atom.workspace.getActiveTextEditor();
         var settings = config.get('linter-rorybot');
 
         if (minimatch(editor.getPath(), settings.ignoreFiles)) {
@@ -125,11 +130,13 @@ function linter() {
     }
 
     return {
-        'grammarScopes': config.get('linter-rorybot').grammars,
-        'name': 'rorybot',
-        'scope': 'file',
-        'lintOnFly': true,
-        'lint': onchange
+        grammarScopes: config.get('linter-rorybot').grammars,
+        name: 'rorybot',
+        scope: 'file',
+        lintsOnChange: true,
+        lint() {
+          return onchange();
+        }
     };
 }
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "providedServices": {
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   },


### PR DESCRIPTION
Base linter 1.0 doesn't work with the latest releases of Atom. 
This PR updates linter-rorybot to base linter 2.0 re: https://steelbrain.me/linter/guides/upgrading-to-standard-linter-v2.html including several changes to the structure of linter messages. 

Support for HTML tags in lint messages was removed in 2.0 and replaced with markdown. A PR with support for markdown markup in lint messages will follow.

@adamhollett Not sure if you're still interested in this project, but if you give this PR a quick look that would be great!